### PR TITLE
Feat/us 6 user update

### DIFF
--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/UserController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/UserController.java
@@ -5,9 +5,9 @@ import com.pcs.tradingapp.dto.request.CreateUserDto;
 import com.pcs.tradingapp.dto.request.UpdateUserDto;
 import com.pcs.tradingapp.dto.response.UserInfoDto;
 import com.pcs.tradingapp.exceptions.RoleNotFoundException;
+import com.pcs.tradingapp.exceptions.UserNotFoundException;
 import com.pcs.tradingapp.exceptions.UsernameAlreadyExistsException;
 import com.pcs.tradingapp.repositories.UserRepository;
-import com.pcs.tradingapp.services.UserMapper;
 import com.pcs.tradingapp.services.UserService;
 
 import jakarta.validation.Valid;
@@ -15,7 +15,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -30,9 +29,6 @@ public class UserController {
     
     @Autowired
     private UserRepository userRepository;
-    
-    @Autowired
-    private UserMapper mapper;
     
     public UserController(UserService service) {
     	this.service = service;
@@ -78,28 +74,29 @@ public class UserController {
     }
 
     @GetMapping("/user/update/{id}")
-    public String showUpdateForm(@PathVariable Integer id, Model model) {
-        User dbUser = userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid user Id:" + id));
-        UpdateUserDto user =  mapper.userToUpdateUserDto(dbUser);
+    public String showUpdateForm(@PathVariable Integer id, Model model) throws UserNotFoundException {
+        UpdateUserDto user = service.fetchUpdateUserDto(id);
+        
         user.setPassword("");
         model.addAttribute("user", user);
+       
         return "user/update";
     }
 
     @PostMapping("/user/update/{id}")
-    public String updateUser(@PathVariable Integer id, @Valid User user,
-                             BindingResult result, Model model) {
+    public String updateUser(@PathVariable Integer id, @Valid @ModelAttribute("user") UpdateUserDto user, BindingResult result, Model model) throws RoleNotFoundException, UserNotFoundException {
         if (result.hasErrors()) {
             return "user/update";
         }
-
-        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        user.setPassword(encoder.encode(user.getPassword()));
-        user.setId(id);
-        userRepository.save(user);
-        model.addAttribute("users", userRepository.findAll());
-        return "redirect:/user/list";
-    }
+        
+    	try {
+			service.updateUser(user);
+		} catch (UsernameAlreadyExistsException e) {
+			result.rejectValue("username", null, e.getMessage());
+			return "user/update";
+		}
+		return "redirect:/user/list";
+	}
 
     @GetMapping("/user/delete/{id}")
     public String deleteUser(@PathVariable Integer id, Model model) {

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/UserController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/UserController.java
@@ -2,16 +2,19 @@ package com.pcs.tradingapp.controllers;
 
 import com.pcs.tradingapp.domain.User;
 import com.pcs.tradingapp.dto.request.CreateUserDto;
+import com.pcs.tradingapp.dto.request.UpdateUserDto;
 import com.pcs.tradingapp.dto.response.UserInfoDto;
 import com.pcs.tradingapp.exceptions.RoleNotFoundException;
 import com.pcs.tradingapp.exceptions.UsernameAlreadyExistsException;
 import com.pcs.tradingapp.repositories.UserRepository;
+import com.pcs.tradingapp.services.UserMapper;
 import com.pcs.tradingapp.services.UserService;
 
 import jakarta.validation.Valid;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -25,7 +28,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 public class UserController {
     private final UserService service;
     
+    @Autowired
     private UserRepository userRepository;
+    
+    @Autowired
+    private UserMapper mapper;
     
     public UserController(UserService service) {
     	this.service = service;
@@ -72,7 +79,8 @@ public class UserController {
 
     @GetMapping("/user/update/{id}")
     public String showUpdateForm(@PathVariable Integer id, Model model) {
-        User user = userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid user Id:" + id));
+        User dbUser = userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid user Id:" + id));
+        UpdateUserDto user =  mapper.userToUpdateUserDto(dbUser);
         user.setPassword("");
         model.addAttribute("user", user);
         return "user/update";

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/UpdateUserDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/UpdateUserDto.java
@@ -1,0 +1,15 @@
+package com.pcs.tradingapp.dto.request;
+
+public class UpdateUserDto extends CreateUserDto {
+	private int id;
+	
+	public UpdateUserDto(){}
+	
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/GlobalExceptionHandler.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.pcs.tradingapp.exceptions;
+
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(UserNotFoundException.class)
+	public String handleUserNotFound(UserNotFoundException e, Model model) {
+		model.addAttribute("errorMsg", e.getMessage());
+		return "error";
+	}
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserMapper.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserMapper.java
@@ -21,6 +21,9 @@ public interface UserMapper {
 	@Mapping(target = "role", expression = "java(user.getRole().getName().name())")
 	public UpdateUserDto userToUpdateUserDto(User user);
 	
+	@Mapping(target="role", ignore=true)
+	public User updateUserDtoToUser (UpdateUserDto userDto);
+	
 	@Mapping(target="id", ignore=true)
 	@Mapping(target="role", ignore=true)
 	public User createUserDtoToUser(CreateUserDto userDto);

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserMapper.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserMapper.java
@@ -7,6 +7,7 @@ import org.mapstruct.Mapping;
 
 import com.pcs.tradingapp.domain.User;
 import com.pcs.tradingapp.dto.request.CreateUserDto;
+import com.pcs.tradingapp.dto.request.UpdateUserDto;
 import com.pcs.tradingapp.dto.response.UserInfoDto;
 
 // génère un bean spring pr le mapper (évite de devoir instancier manuellement avec Mappers.getMapper() )
@@ -15,9 +16,12 @@ public interface UserMapper {
 	@Mapping(target = "role", expression = "java(user.getRole().getName().name())")
 	public UserInfoDto userToUserInfoDto(User user);
 	
+	public List<UserInfoDto> usersToUserInfoDtos(List<User> users);
+	
+	@Mapping(target = "role", expression = "java(user.getRole().getName().name())")
+	public UpdateUserDto userToUpdateUserDto(User user);
+	
 	@Mapping(target="id", ignore=true)
 	@Mapping(target="role", ignore=true)
 	public User createUserDtoToUser(CreateUserDto userDto);
-	
-	public List<UserInfoDto> usersToUserInfoDtos(List<User> users);
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
 		this.roleRepository = roleRepository;
 	}
 	
-	public Role fetchUserRole(String roleString, User user) throws RoleNotFoundException {		
+	public Role fetchUserRole(String roleString) throws RoleNotFoundException {		
 		RoleName roleName = null;
 		
 		try {
@@ -78,7 +78,7 @@ public class UserService {
         
         User user = mapper.createUserDtoToUser(userDto);
         
-        Role role = fetchUserRole(userDto.getRole(), user);
+        Role role = fetchUserRole(userDto.getRole());
         user.setRole(role);
         
         repository.save(user);
@@ -100,7 +100,7 @@ public class UserService {
         
         User userToUpdate = mapper.updateUserDtoToUser(userDto);
         
-        Role role = fetchUserRole(userDto.getRole(), userToUpdate);        
+        Role role = fetchUserRole(userDto.getRole());        
         userToUpdate.setRole(role);
         
         repository.save(userToUpdate);

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserService.java
@@ -12,6 +12,7 @@ import com.pcs.tradingapp.domain.User;
 import com.pcs.tradingapp.dto.request.CreateUserDto;
 import com.pcs.tradingapp.dto.response.UserInfoDto;
 import com.pcs.tradingapp.exceptions.RoleNotFoundException;
+import com.pcs.tradingapp.exceptions.UserNotFoundException;
 import com.pcs.tradingapp.exceptions.UsernameAlreadyExistsException;
 import com.pcs.tradingapp.repositories.RoleRepository;
 import com.pcs.tradingapp.repositories.UserRepository;
@@ -26,6 +27,40 @@ public class UserService {
 		this.repository = repository;
 		this.mapper = mapper;
 		this.roleRepository = roleRepository;
+	}
+	
+	public Role fetchUserRole(String roleString, User user) throws RoleNotFoundException {		
+		RoleName roleName = null;
+		
+		try {
+            roleName = RoleName.valueOf(roleString);
+        } catch (IllegalArgumentException ex) {
+            throw new RoleNotFoundException(ApiMessages.ROLE_NOT_FOUND);
+        }
+        
+        Role role = roleRepository.findByName(roleName);
+        
+        if (role == null) {
+        	throw new RoleNotFoundException(ApiMessages.ROLE_NOT_FOUND);
+        }
+        
+        return role;
+	}
+	
+	public boolean validateUsernameIsAvailable(String username) throws UsernameAlreadyExistsException {
+		if (repository.findByUsername(username).isPresent()) {
+			throw new UsernameAlreadyExistsException(ApiMessages.USERNAME_ALREADY_EXISTS);
+		}
+		
+		return true;
+	}
+	
+	public boolean validateUserExists(int id) throws UserNotFoundException {
+		if (repository.findById(id) == null) {
+        	throw new UserNotFoundException(ApiMessages.USER_NOT_FOUND);
+        }
+		
+		return true;
 	}
 	
 	public List<UserInfoDto> getAllUsers() {

--- a/trading-app-demo/src/main/resources/templates/error.html
+++ b/trading-app-demo/src/main/resources/templates/error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+      <title>Spring Boot</title>
+</head>
+<body>
+   <h3>Oops... An error occured.</h3> 
+    <p class="error" th:text="${errorMsg}">Error</p>
+</body>
+</html>   

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/services/UserServiceTest.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/services/UserServiceTest.java
@@ -34,7 +34,7 @@ public class UserServiceTest {
 		when(roleRepository.findByName(RoleName.USER)).thenReturn(null);
 		
 		//act and assert: service shoul throw exception
-		assertThrows(RoleNotFoundException.class, ()-> service.fetchUserRole("USER", new User()));
+		assertThrows(RoleNotFoundException.class, ()-> service.fetchUserRole("USER"));
 	}
 	
 	@Test

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/services/UserServiceTest.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/services/UserServiceTest.java
@@ -1,0 +1,47 @@
+package com.pcs.tradingapp.services;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pcs.tradingapp.domain.RoleName;
+import com.pcs.tradingapp.domain.User;
+import com.pcs.tradingapp.exceptions.RoleNotFoundException;
+import com.pcs.tradingapp.exceptions.UserNotFoundException;
+import com.pcs.tradingapp.repositories.RoleRepository;
+import com.pcs.tradingapp.repositories.UserRepository;
+
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+	@Mock
+	private RoleRepository roleRepository;
+	
+	@Mock
+	private UserRepository userRepository;
+	
+	@InjectMocks
+	private UserService service;
+	
+	@Test
+	public void testFetchRole_shouldThrowException() throws Exception {
+		//assert: repository don't find the role
+		when(roleRepository.findByName(RoleName.USER)).thenReturn(null);
+		
+		//act and assert: service shoul throw exception
+		assertThrows(RoleNotFoundException.class, ()-> service.fetchUserRole("USER", new User()));
+	}
+	
+	@Test
+	public void testValidateUserExists_shouldThrowException() throws Exception {
+		int userId = 999;
+		when(userRepository.findById(userId)).thenReturn(null);
+		
+		assertThrows(UserNotFoundException.class, ()-> service.validateUserExists(userId));
+	}
+}


### PR DESCRIPTION
[User] CRUD partiel : Update de l'entité User avec DTO

## Description
Cette PR poursuit l'implémentation du CRUD utilisateur en introduisant :
- le pattern DTO pour le formulaire de mise à jour utilisateur (`UpdateUserDto`), afin de résoudre les incompatibilités de type entre l’entité User et la vue,
- un gestionnaire global d’exception pour `UserNotFoundException`, avec une vue d’erreur générique affichant les messages,
- des tests d’intégration couvrant l’affichage et la soumission du formulaire de mise à jour avec validation des champs,
- des tests unitaires couvrant les méthodes de validation métier dans le service.

## Principales modifications

### DTO
- Ajout de `UpdateUserDto` (héritant de `CreateUserDto`) avec un champ `id` pour représenter les données nécessaires au formulaire de mise à jour utilisateur.
- Mise à jour du contrôleur pour utiliser ce DTO dans la méthode `showUpdateForm()` afin de ne pas exposer l'entité User directement à la vue.

### Services

#### UserMapper
- Ajout de la méthode `userToUpdateUserDto(User user)`.
- Ajout de la méthode `updateUserDtoToUser(UpdateUserDto dto)`, avec l’annotation `@Mapping(target="role", ignore=true)` pour déléguer la gestion du rôle au service.

#### UserService
- Ajout des méthodes `updateUser()` et `fetchUpdateUserDto()` pour gérer la mise à jour.
- Extraction de la logique de validation métier dans des méthodes dédiées pour faciliter la maintenance et éviter la duplication du code :
  - `fetchUserRole(String roleString)` : convertit la chaîne en `RoleName`, récupère le `Role` associé, ou lève une exception si non trouvé.
  - `validateUserExists()` : lève une `UserNotFoundException` si l'utilisateur n'existe pas.
  - `validateUsernameIsAvailable()` : lève une `UsernameAlreadyExistsException` si le username est déjà pris.

### UserController
- Refactorisation de la méthode `updateUser()` pour déléguer la logique métier au service.
- Gestion des erreurs de formulaire (`BindingResult`) et de l’exception `UsernameAlreadyExistsException` (le message est bindé au champ du formulaire).
- Redirection vers `/user/list` en cas de succès.

### Gestion des erreurs
- Ajout d’un template d’erreur générique.
- Création d’un gestionnaire global `@ControllerAdvice` pour traiter les `UserNotFoundException` et afficher le message dans la vue "error". 

**Note**
RoleNotFoundException n'est pas capturée par le Controller advice pour ne pas afficher proprement une erreur à l'utilisateur qui pourrait masquer une exception technique peu probable par un message utilisateur générique. 

---

## Tests

### Tests d’intégration
- Ajout de tests pour :
  - la création d’utilisateur avec un username déjà utilisé (vérification des erreurs dans le formulaire),
  - l’affichage et la soumission du formulaire de mise à jour (succès, mot de passe invalide, username indisponible, utilisateur inconnu),
  - l’affichage des vues associées.
- Reset du contexte Spring entre chaque test pour garantir l’isolation (`@DirtiesContext`).

### Tests unitaires
- Ajout de tests unitaires pour `UserService` afin de vérifier que les exceptions sont correctement levées lorsque :
  - le rôle demandé n’existe pas,
  - l’utilisateur demandé n’existe pas.
