### PR TITLE
Feat/us 6.4 user delete

### DIFF
--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/UserController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/UserController.java
@@ -1,20 +1,17 @@
 package com.pcs.tradingapp.controllers;
 
-import com.pcs.tradingapp.domain.User;
 import com.pcs.tradingapp.dto.request.CreateUserDto;
 import com.pcs.tradingapp.dto.request.UpdateUserDto;
 import com.pcs.tradingapp.dto.response.UserInfoDto;
 import com.pcs.tradingapp.exceptions.RoleNotFoundException;
 import com.pcs.tradingapp.exceptions.UserNotFoundException;
 import com.pcs.tradingapp.exceptions.UsernameAlreadyExistsException;
-import com.pcs.tradingapp.repositories.UserRepository;
 import com.pcs.tradingapp.services.UserService;
 
 import jakarta.validation.Valid;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -26,9 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Controller
 public class UserController {
     private final UserService service;
-    
-    @Autowired
-    private UserRepository userRepository;
     
     public UserController(UserService service) {
     	this.service = service;
@@ -99,10 +93,9 @@ public class UserController {
 	}
 
     @GetMapping("/user/delete/{id}")
-    public String deleteUser(@PathVariable Integer id, Model model) {
-        User user = userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid user Id:" + id));
-        userRepository.delete(user);
-        model.addAttribute("users", userRepository.findAll());
+    public String deleteUser(@PathVariable Integer id, Model model) throws UserNotFoundException {
+    	service.deleteUser(id); 
+        
         return "redirect:/user/list";
     }
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/UserService.java
@@ -105,4 +105,10 @@ public class UserService {
         
         repository.save(userToUpdate);
 	}
+
+	public void deleteUser(Integer id) throws UserNotFoundException {
+		User user = repository.findById(id).orElseThrow( () -> new UserNotFoundException(ApiMessages.USER_NOT_FOUND));
+		
+        repository.delete(user);
+	}
 }

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/UserControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/UserControllerIT.java
@@ -156,6 +156,22 @@ public class UserControllerIT {
     		.andExpect(redirectedUrl("/user/list"));
     }
     
+    @Test
+    public void testDeleteUser_shouldReturnUsersListView() throws Exception {
+    	mockMvc.perform(get("/user/delete/2"))
+    	
+    	.andExpect(status().is3xxRedirection())
+    	.andExpect(redirectedUrl("/user/list"));
+    }
+    
+    @Test
+    public void testDeleteUser_shouldRedirectToErrorView() throws Exception {
+    	mockMvc.perform(get("/user/delete/999"))
+    	
+    	.andExpect(status().is2xxSuccessful())
+    	.andExpect(view().name("error"));
+    }
+    
     /**
      * This test ensures robustness against potential inconsistencies. 
      * 

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/services/UserServiceTest.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/services/UserServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.pcs.tradingapp.domain.RoleName;
-import com.pcs.tradingapp.domain.User;
 import com.pcs.tradingapp.exceptions.RoleNotFoundException;
 import com.pcs.tradingapp.exceptions.UserNotFoundException;
 import com.pcs.tradingapp.repositories.RoleRepository;


### PR DESCRIPTION
# [User] fin du CRUD - opération DELETE

## Description

Cette PR introduit la **dernière partie du CRUD** de l'entité User en permettant les opérations de suppression d'utilisateurs. 

## Principales modifications
### UserService
Ajout de la méthode deleteUser(id) : 
 - récupère l'entité User via la méthode findById(int id) du UserRepository, 
 - lance une UserNotFoundException si le User n'est pas trouvé,
 - supprime l'utilisateur via le Repository.  

### UserController
Appelle le service et propage l'exception UserNotFoundException si elle survient. 

--- 

### Exceptions
#### UserNotFoundException
**Rappel**
L'exception est gérée par un `@ExceptionHandler` qui la traite en affichant une page d'erreur en cas d'utilisateur non trouvé en BDD. 

--- 

## Tests
### UserControllerIt
Ajout de tests d’intégration pour la suppression d’utilisateur :
 - vérification de la redirection vers la liste des utilisateurs après suppression réussie,
 - vérification de l’affichage de la page d’erreur si l’utilisateur à supprimer n’existe pas.

--- 

Cette PR clôture l’implémentation du CRUD complet pour l’entité User.
