### PR TITLE
Feat/us2 curve point crud

### DIFF
--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
@@ -5,4 +5,5 @@ public class ApiMessages {
 	public static final String USERNAME_ALREADY_EXISTS = "This username already exists";
 	public static final String ROLE_NOT_FOUND = "Role not found";
 	public static final String BIDLIST_NOT_FOUND = "Bid list not found";
+	public static final String CURVEPOINT_NOT_FOUND = "Curve point is not found";
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/CurvePointController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/CurvePointController.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.pcs.tradingapp.domain.CurvePoint;
 import com.pcs.tradingapp.dto.request.curvepoint.CreateCurvePointDto;
+import com.pcs.tradingapp.dto.request.curvepoint.UpdateCurvePointDto;
 import com.pcs.tradingapp.dto.response.CurvePointInfoDto;
 import com.pcs.tradingapp.exceptions.CurvePointNotFoundException;
 import com.pcs.tradingapp.services.curvepoint.CurvePointService;
@@ -63,15 +64,20 @@ public class CurvePointController {
     }
 
     @PostMapping("/curvepoint/update/{id}")
-    public String updateCurvePoint(@PathVariable Integer id, @Valid CurvePoint curvePoint,
+    public String updateCurvePoint(@PathVariable Integer id, @Valid @ModelAttribute("curvePoint") UpdateCurvePointDto curvePoint,
                              BindingResult result, Model model) {
-        // TODO: check required fields, if valid call service to update Curve and return Curve list
-        return "redirect:/curvePoint/list";
+    	if (result.hasErrors()) {
+    		return "/curvePoint/update";
+    	}
+    	
+        service.updateCurvePoint(curvePoint);
+    	
+        return "redirect:/curvepoint/list";
     }
 
     @GetMapping("/curvepoint/delete/{id}")
     public String deleteCurvePoint(@PathVariable Integer id, Model model) {
         // TODO: Find Curve by Id and delete the Curve, return to Curve list
-        return "redirect:/curvePoint/list";
+        return "redirect:/curvepoint/list";
     }
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/CurvePointController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/CurvePointController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.pcs.tradingapp.domain.CurvePoint;
 import com.pcs.tradingapp.dto.request.curvepoint.CreateCurvePointDto;
 import com.pcs.tradingapp.dto.response.CurvePointInfoDto;
+import com.pcs.tradingapp.exceptions.CurvePointNotFoundException;
 import com.pcs.tradingapp.services.curvepoint.CurvePointService;
 
 @Controller
@@ -49,9 +51,15 @@ public class CurvePointController {
     }
 
     @GetMapping("/curvepoint/update/{id}")
-    public String showUpdateForm(@PathVariable Integer id, Model model) {
-        // TODO: get CurvePoint by Id and to model then show to the form
-        return "curvePoint/update";
+    public String showUpdateForm(@PathVariable Integer id, Model model, RedirectAttributes redirectAttributes) {
+    	try {
+			CurvePointInfoDto curvePoint = service.getCurvePoint(id);
+			model.addAttribute("curvePoint", curvePoint);
+			return "curvePoint/update";
+		} catch (CurvePointNotFoundException e) {
+			redirectAttributes.addFlashAttribute("errorMsg", e.getMessage());
+			return "redirect:/curvepoint/list";
+		}
     }
 
     @PostMapping("/curvepoint/update/{id}")

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/curvepoint/UpdateCurvePointDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/curvepoint/UpdateCurvePointDto.java
@@ -1,0 +1,13 @@
+package com.pcs.tradingapp.dto.request.curvepoint;
+
+public class UpdateCurvePointDto extends CreateCurvePointDto {
+	private int id;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/CurvePointNotFoundException.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/CurvePointNotFoundException.java
@@ -1,0 +1,13 @@
+package com.pcs.tradingapp.exceptions;
+
+public class CurvePointNotFoundException extends Exception {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	
+	public CurvePointNotFoundException(String message) {
+		super(message);
+	}
+
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointMapper.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointMapper.java
@@ -7,6 +7,7 @@ import org.mapstruct.ReportingPolicy;
 
 import com.pcs.tradingapp.domain.CurvePoint;
 import com.pcs.tradingapp.dto.request.curvepoint.CreateCurvePointDto;
+import com.pcs.tradingapp.dto.request.curvepoint.UpdateCurvePointDto;
 import com.pcs.tradingapp.dto.response.CurvePointInfoDto;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -16,4 +17,6 @@ public interface CurvePointMapper {
 	public List<CurvePointInfoDto> curvePointsToCurvePointInfoDtos(List<CurvePoint> curvePoint);
 
 	public CurvePoint createCurvePointDtoToCurvePoint(CreateCurvePointDto dto);
+
+	public CurvePoint updateCurvePointDtoToCurvePoint(UpdateCurvePointDto curvePoint);
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import com.pcs.tradingapp.constants.ApiMessages;
 import com.pcs.tradingapp.domain.CurvePoint;
 import com.pcs.tradingapp.dto.request.curvepoint.CreateCurvePointDto;
+import com.pcs.tradingapp.dto.request.curvepoint.UpdateCurvePointDto;
 import com.pcs.tradingapp.dto.response.CurvePointInfoDto;
 import com.pcs.tradingapp.exceptions.CurvePointNotFoundException;
 import com.pcs.tradingapp.repositories.CurvePointRepository;
@@ -40,5 +41,11 @@ public class CurvePointService {
 		CurvePoint curvePoint = repository.findById(id).orElseThrow(() -> new CurvePointNotFoundException(ApiMessages.CURVEPOINT_NOT_FOUND));
 		
 		return mapper.curvePointToCurvePointInfoDto(curvePoint);
+	}
+
+	public void updateCurvePoint(UpdateCurvePointDto curvePoint) {
+		CurvePoint curvePointToUpdate = mapper.updateCurvePointDtoToCurvePoint(curvePoint); 
+		
+		repository.save(curvePointToUpdate);
 	}
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointService.java
@@ -5,9 +5,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.pcs.tradingapp.constants.ApiMessages;
 import com.pcs.tradingapp.domain.CurvePoint;
 import com.pcs.tradingapp.dto.request.curvepoint.CreateCurvePointDto;
 import com.pcs.tradingapp.dto.response.CurvePointInfoDto;
+import com.pcs.tradingapp.exceptions.CurvePointNotFoundException;
 import com.pcs.tradingapp.repositories.CurvePointRepository;
 
 @Service
@@ -32,5 +34,11 @@ public class CurvePointService {
 		curvePoint.setCreationDate(LocalDateTime.now());
 		
 		repository.save(curvePoint);
+	}
+
+	public CurvePointInfoDto getCurvePoint(Integer id) throws CurvePointNotFoundException {
+		CurvePoint curvePoint = repository.findById(id).orElseThrow(() -> new CurvePointNotFoundException(ApiMessages.CURVEPOINT_NOT_FOUND));
+		
+		return mapper.curvePointToCurvePointInfoDto(curvePoint);
 	}
 }

--- a/trading-app-demo/src/main/resources/templates/curvePoint/list.html
+++ b/trading-app-demo/src/main/resources/templates/curvePoint/list.html
@@ -50,6 +50,7 @@
 			</tbody>
 		</table>
 	</div>
+	<p class="text-danger" th:if="${errorMsg != null}" th:text="${errorMsg}"></p>
 </div>
 </body>
 </html>

--- a/trading-app-demo/src/main/resources/templates/curvePoint/update.html
+++ b/trading-app-demo/src/main/resources/templates/curvePoint/update.html
@@ -32,7 +32,7 @@
 			<div class="form-group">
 				<label for="value" class="col-sm-2 control-label">Value</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{value}" id="value" placeholder="Value" class="col-4">
+					<input type="text" th:field="*{value}" id="value" placeholder="Value" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('value')}" th:errors="*{value}"></p>
 				</div>
 			</div>

--- a/trading-app-demo/src/main/resources/templates/curvePoint/update.html
+++ b/trading-app-demo/src/main/resources/templates/curvePoint/update.html
@@ -15,6 +15,14 @@
 	<div class="row">
 		<form action="#" th:action="@{/curvepoint/update/{id}(id=${curvePoint.id})}" th:object="${curvePoint}" method="post" class="form-horizontal" style="width: 100%">
 			<div class="form-group">
+				<label for="curveId" class="col-sm-2 control-label">Curve Id</label>
+				<div class="col-sm-10">
+					<input type="text" th:field="*{curveId}" id="curveId" placeholder="Curve Id" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('curveId')}" th:errors="*{curveId}"></p>
+				</div>
+			</div>
+						
+			<div class="form-group">
 				<label for="term" class="col-sm-2 control-label">Term</label>
 				<div class="col-sm-10">
 					<input type="text" th:field="*{term}" id="term" placeholder="Term" class="col-4">

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/CurvePointControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/CurvePointControllerIT.java
@@ -82,5 +82,30 @@ public class CurvePointControllerIT {
                 .andExpect(redirectedUrl("/curvepoint/list"))
                 .andExpect(flash().attributeExists("errorMsg"));
     }
+    
+    @Test
+    public void testUpdateCurvePoint_withValidData_ShouldRedirectToListView() throws Exception {
+    	mockMvc.perform(post("/curvepoint/update/1")
+    			.param("curveId", "54")
+    			.param("term", "15")
+    			.param("value", "1")
+			)
+    		
+    		.andExpect(status().is3xxRedirection())
+    		.andExpect(redirectedUrl("/curvepoint/list"));
+    }
+    
+    @Test
+    public void testUpdateCurvePoint_withInvalidValues_ShouldReturnError() throws Exception {
+    	mockMvc.perform(post("/curvepoint/update/1")
+    			.param("curveId", "1.2")
+    			.param("term", "12.2")
+    			.param("value", "1.4")
+    			)
+
+    	.andExpect(status().isOk())
+    	.andExpect(model().attributeHasFieldErrors("curvePoint", "curveId"))
+    	.andExpect(view().name("/curvePoint/update"));
+    }
 
 }

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/CurvePointControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/CurvePointControllerIT.java
@@ -2,6 +2,7 @@ package com.pcs.tradingapp.it;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,4 +66,21 @@ public class CurvePointControllerIT {
     	.andExpect(model().attributeHasFieldErrors("curvePoint", "curveId"))
     	.andExpect(view().name("curvePoint/add"));
     }
+    
+    @Test
+    public void testShowUpdateForm_withExistingId_shouldReturnUpdateView() throws Exception {
+        mockMvc.perform(get("/curvepoint/update/1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("curvePoint/update"))
+                .andExpect(model().attributeExists("curvePoint"));
+    }
+
+    @Test
+    public void testShowUpdateForm_withUnknownId_shouldRedirectToListWithError() throws Exception {
+        mockMvc.perform(get("/curvepoint/update/777"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/curvepoint/list"))
+                .andExpect(flash().attributeExists("errorMsg"));
+    }
+
 }


### PR DESCRIPTION
# [CRUD] Mise à jour de CurvePoints (UPDATE)

## Description
Cette PR introduit la troisième étape du CRUD pour l’entité CurvePoint, avec l’implémentation de l’opération de mise à jour.
Elle inclut également des correctifs sur le template qui améliorent l'expérience utilisateur.

## Principales modifications
### Templates
curvePoint/update
Ajout du champ manquant « Curve Id », de type text et correction du type d’input pour "value".

Le type text permet de désactiver la validation du navigateur afin de ne pas laisser les messages du navigateur masquer les messages d'erreur explicites du backend.

### DTO et mapping
Création de  UpdateCurvePointDto, qui étend la classe CreateCurvePointDto, pour les données des requêtes de mise à jour. 
Ajout de la propriété `id`. 

Ajout d’un mapper pour convertir le DTO en entité CurvePoint.

### Service
Ajout de la méthode updateCurvePoint() dans le service, qui mappe le DTO vers une entité via le mapper, et persiste l’entité via le repository.

### Controller
Utilisation du DTO pour le binding et la validation du formulaire de mise à jour.
Gestion explicite du binding et des erreurs via @ModelAttribute.

--- 

## Tests
Ajout de tests d’intégration pour :
 - la mise à jour avec données valides (redirection),
 - la mise à jour avec données invalides (affiche le formulaire avec erreurs).