### PR TITLE
Feat/us2 curve point crud

### DIFF
--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/CurvePointController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/CurvePointController.java
@@ -76,8 +76,12 @@ public class CurvePointController {
     }
 
     @GetMapping("/curvepoint/delete/{id}")
-    public String deleteCurvePoint(@PathVariable Integer id, Model model) {
-        // TODO: Find Curve by Id and delete the Curve, return to Curve list
-        return "redirect:/curvepoint/list";
+    public String deleteCurvePoint(@PathVariable Integer id, Model model, RedirectAttributes redirectAttributes) {
+    	try {
+			service.deleteCurvePoint(id);
+		} catch (CurvePointNotFoundException e) {
+			redirectAttributes.addFlashAttribute("errorMsg", e.getMessage());
+		}
+		return "redirect:/curvepoint/list";
     }
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/curvepoint/CurvePointService.java
@@ -48,4 +48,11 @@ public class CurvePointService {
 		
 		repository.save(curvePointToUpdate);
 	}
+
+	public void deleteCurvePoint(Integer id) throws CurvePointNotFoundException {
+	    if (repository.findById(id).isEmpty()) {
+	        throw new CurvePointNotFoundException(ApiMessages.CURVEPOINT_NOT_FOUND);
+	    }
+	    repository.deleteById(id);
+	}
 }

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/CurvePointControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/CurvePointControllerIT.java
@@ -107,5 +107,19 @@ public class CurvePointControllerIT {
     	.andExpect(model().attributeHasFieldErrors("curvePoint", "curveId"))
     	.andExpect(view().name("/curvePoint/update"));
     }
-
+    
+    @Test
+    public void testDeleteCurvePoint_shouldRedirectToList() throws Exception {
+        mockMvc.perform(get("/curvepoint/delete/1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/curvepoint/list"));
+    }
+    
+    @Test
+    public void testDeleteCurvePoint_shouldReturnError() throws Exception {
+        mockMvc.perform(get("/curvepoint/delete/78568"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/curvepoint/list"))
+                .andExpect(flash().attributeExists("errorMsg"));
+    }
 }


### PR DESCRIPTION
# [CRUD] Suppression de CurvePoints (DELETE)

## Description
Cette PR introduit la **dernière étape du CRUD** pour l’entité CurvePoint, avec l’implémentation de l’opération de suppression.

## Principales modifications
### Service
Ajout de la méthode `deleteCurvePoint(int id)` dans CurvePointService qui : 
 - **vérifie** si l'id fourni existe, 
 - lance une **CurvePointNotFoundException** le cas échéant, 
 - **supprime** le CurvePoint via le CurvePointRepository. 

### Controller
Utilisation du service pour la suppression du CurvePoint.
Après toute tentative de suppression, l'utilisateur est redirigé vers la page d'index (/curvepoint/list).

Utilisation de **RedirectAttributes** pour ajouter un flash attribute afin d’afficher un message d’erreur lors de la redirection vers la page "/curvepoint/list".

---

## Tests
Ajout de **tests d’intégration** pour :

la **suppression d'un CurvePoint existant** (redirection vers la liste de curve points),
la **suppression d'un CurvePoint inconnu** (redirection vers la liste avec message d'erreur).