### PR TITLE
Feat/us3 rating crud

### DIFF
--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
@@ -4,7 +4,11 @@ public class ApiMessages {
 	public final static String USER_NOT_FOUND = "User not found.";
 	public static final String USERNAME_ALREADY_EXISTS = "This username already exists";
 	public static final String ROLE_NOT_FOUND = "Role not found";
+	
 	public static final String BIDLIST_NOT_FOUND = "Bid list not found";
+	
 	public static final String CURVEPOINT_NOT_FOUND = "Curve point is not found";
+	
 	public static final String RATING_NOT_FOUND = "Rating is not found";
+	public static final String RATING_ORDER_NUMBER_EXISTS = "Rating order nuber already exists";
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
@@ -10,5 +10,5 @@ public class ApiMessages {
 	public static final String CURVEPOINT_NOT_FOUND = "Curve point is not found";
 	
 	public static final String RATING_NOT_FOUND = "Rating is not found";
-	public static final String RATING_ORDER_NUMBER_EXISTS = "Rating order nuber already exists";
+	public static final String RATING_ORDER_NUMBER_EXISTS = "Rating order number already exists";
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/constants/ApiMessages.java
@@ -6,4 +6,5 @@ public class ApiMessages {
 	public static final String ROLE_NOT_FOUND = "Role not found";
 	public static final String BIDLIST_NOT_FOUND = "Bid list not found";
 	public static final String CURVEPOINT_NOT_FOUND = "Curve point is not found";
+	public static final String RATING_NOT_FOUND = "Rating is not found";
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
@@ -69,10 +69,14 @@ public class RatingController {
     }
 
     @PostMapping("/rating/update/{id}")
-    public String updateRating(@PathVariable Integer id, @Valid Rating rating,
-                             BindingResult result, Model model) {
-        // TODO: check required fields, if valid call service to update Rating and return Rating list
-        return "redirect:/rating/list";
+    public String updateRating(@PathVariable Integer id, @Valid @ModelAttribute("rating") UpdateRatingDto rating,
+                             BindingResult result, Model model, RedirectAttributes redirectAttributes) {
+    	if (result.hasErrors()) {
+    		return "rating/update";
+    	}
+		service.updateRating(rating);
+
+    	return "redirect:/rating/list";
     }
 
     @GetMapping("/rating/delete/{id}")

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import com.pcs.tradingapp.domain.Rating;
+import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
 import com.pcs.tradingapp.services.rating.RatingService;
 
@@ -32,7 +34,7 @@ public class RatingController {
     }
 
     @GetMapping("/rating/add")
-    public String addRatingForm(Rating rating) {
+    public String addRatingForm(@ModelAttribute("rating") CreateRatingDto rating) {
         return "rating/add";
     }
 

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.pcs.tradingapp.domain.Rating;
 import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
+import com.pcs.tradingapp.dto.request.rating.UpdateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
+import com.pcs.tradingapp.exceptions.RatingNotFoundException;
 import com.pcs.tradingapp.exceptions.RatingOrderNumberAlreadyExistsException;
 import com.pcs.tradingapp.services.rating.RatingService;
 
@@ -80,8 +82,13 @@ public class RatingController {
     }
 
     @GetMapping("/rating/delete/{id}")
-    public String deleteRating(@PathVariable Integer id, Model model) {
-        // TODO: Find Rating by Id and delete the Rating, return to Rating list
+    public String deleteRating(@PathVariable Integer id, Model model, RedirectAttributes redirectAttributes) {
+        try {
+			service.deleteRating(id);
+		} catch (RatingNotFoundException e) {
+			redirectAttributes.addFlashAttribute("errorMsg", e.getMessage());
+		}
+        
         return "redirect:/rating/list";
     }
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import com.pcs.tradingapp.domain.Rating;
 import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
+import com.pcs.tradingapp.exceptions.RatingOrderNumberAlreadyExistsException;
 import com.pcs.tradingapp.services.rating.RatingService;
 
 @Controller
@@ -38,10 +39,19 @@ public class RatingController {
         return "rating/add";
     }
 
-    @PostMapping("/rating/validate")
-    public String validate(@Valid Rating rating, BindingResult result, Model model) {
-        // TODO: check data valid and save to db, after saving return Rating list
-        return "rating/add";
+    @PostMapping("/rating/add")
+    public String createRating(@Valid @ModelAttribute("rating") CreateRatingDto rating, BindingResult result, Model model) {
+    	if (result.hasFieldErrors()) {
+    		return "rating/add";
+    	}
+    	
+        try {
+			service.createRating(rating);
+			return "redirect:/rating/list";
+		} catch (RatingOrderNumberAlreadyExistsException e) {
+			result.rejectValue("order", "error.order", e.getMessage());
+			return "rating/add";
+		}
     }
 
     @GetMapping("/rating/update/{id}")

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
@@ -2,6 +2,8 @@ package com.pcs.tradingapp.controllers;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -10,16 +12,23 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import com.pcs.tradingapp.domain.Rating;
+import com.pcs.tradingapp.dto.response.RatingInfoDto;
+import com.pcs.tradingapp.services.rating.RatingService;
 
 @Controller
 public class RatingController {
-    // TODO: Inject Rating service
+    private final RatingService service;
+    
+    public RatingController(RatingService service) {
+    	this.service = service;
+    }
 
     @GetMapping("/rating/list")
-    public String home(Model model)
-    {
-        // TODO: find all Rating, add to model
-        return "rating/list";
+    public String index(Model model) {
+    	List<RatingInfoDto> ratings = service.getAllRatings();
+    	model.addAttribute("ratings", ratings);
+        
+    	return "rating/list";
     }
 
     @GetMapping("/rating/add")

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/controllers/RatingController.java
@@ -55,9 +55,17 @@ public class RatingController {
     }
 
     @GetMapping("/rating/update/{id}")
-    public String showUpdateForm(@PathVariable Integer id, Model model) {
-        // TODO: get Rating by Id and to model then show to the form
-        return "rating/update";
+    public String showUpdateForm(@PathVariable Integer id, Model model, RedirectAttributes redirectAttributes) {
+    	try {
+			RatingInfoDto rating = service.getRatingById(id);
+			model.addAttribute("rating", rating);
+			
+			return "rating/update";
+		} catch (RatingNotFoundException e) {
+			redirectAttributes.addFlashAttribute("errorMsg", e.getMessage());
+
+		    return "redirect:/rating/list";
+		}        
     }
 
     @PostMapping("/rating/update/{id}")

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/domain/Rating.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/domain/Rating.java
@@ -7,16 +7,23 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-
 @Entity
 @Table(name = "rating")
 public class Rating {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Id
 	private Integer id;
+	
+	@Column(name="moodys_rating")
 	private String moodysRating;
+	
+	@Column(name = "sand_p_rating")
 	private String sandPRating;
+	
+	@Column(name = "fitch_rating")
 	private String fitchRating;
+	
+	@Column(name = "order_number")
 	private Integer orderNumber;
 
 	public Integer getId() {
@@ -35,7 +42,6 @@ public class Rating {
 		this.moodysRating = moodysRating;
 	}
 	
-	@Column(name = "sand_p_rating")
 	public String getSandPRating() {
 		return sandPRating;
 	}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/CreateRatingDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/CreateRatingDto.java
@@ -1,12 +1,19 @@
 package com.pcs.tradingapp.dto.request.rating;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public class CreateRatingDto {
+	@Pattern(regexp = "^(Aaa|Aa1|Aa2|Aa3|A1|A2|A3|Baa1|Baa2|Baa3|Ba1|Ba2|Ba3|B1|B2|B3|Caa1|Caa2|Caa3|Ca|C)$",
+	         message = "Please enter a valid Moody's rating.")
 	private String moodysRating;
 	
+	@Pattern(regexp = "^(AAA|AA\\+|AA|AA\\-|A\\+|A|A\\-|BBB\\+|BBB|BBB\\-|BB\\+|BB|BB\\-|B\\+|B|B\\-|CCC\\+|CCC|CCC\\-|D)$",
+	         message = "Please enter a valid S&P rating.")
 	private String sandPRating;
 	
+	@Pattern(regexp = "^(AAA|AA\\+|AA|AA\\-|A\\+|A|A\\-|BBB\\+|BBB|BBB\\-|BB\\+|BB|BB\\-|B\\+|B|B\\-|CCC\\+|CCC|CCC\\-|D)$",
+	         message = "Please enter a valid Fitch rating.")
 	private String fitchRating;
 	
 	@NotNull

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/CreateRatingDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/CreateRatingDto.java
@@ -1,0 +1,46 @@
+package com.pcs.tradingapp.dto.request.rating;
+
+import jakarta.validation.constraints.NotNull;
+
+public class CreateRatingDto {
+	private String moodysRating;
+	
+	private String sandPRating;
+	
+	private String fitchRating;
+	
+	@NotNull
+	private Integer order;
+
+	public String getMoodysRating() {
+		return moodysRating;
+	}
+
+	public void setMoodysRating(String moodysRating) {
+		this.moodysRating = moodysRating;
+	}
+
+	public String getSandPRating() {
+		return sandPRating;
+	}
+
+	public void setSandPRating(String sandPRating) {
+		this.sandPRating = sandPRating;
+	}
+
+	public String getFitchRating() {
+		return fitchRating;
+	}
+
+	public void setFitchRating(String fitchRating) {
+		this.fitchRating = fitchRating;
+	}
+
+	public Integer getOrder() {
+		return order;
+	}
+
+	public void setOrder(Integer order) {
+		this.order = order;
+	}
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/CreateRatingDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/CreateRatingDto.java
@@ -1,22 +1,24 @@
 package com.pcs.tradingapp.dto.request.rating;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public class CreateRatingDto {
 	@Pattern(regexp = "^(Aaa|Aa1|Aa2|Aa3|A1|A2|A3|Baa1|Baa2|Baa3|Ba1|Ba2|Ba3|B1|B2|B3|Caa1|Caa2|Caa3|Ca|C)$",
-	         message = "Please enter a valid Moody's rating.")
+	         message = "{moodys.rating.format}")
 	private String moodysRating;
 	
 	@Pattern(regexp = "^(AAA|AA\\+|AA|AA\\-|A\\+|A|A\\-|BBB\\+|BBB|BBB\\-|BB\\+|BB|BB\\-|B\\+|B|B\\-|CCC\\+|CCC|CCC\\-|D)$",
-	         message = "Please enter a valid S&P rating.")
+	         message = "{sandp.rating.format}")
 	private String sandPRating;
 	
 	@Pattern(regexp = "^(AAA|AA\\+|AA|AA\\-|A\\+|A|A\\-|BBB\\+|BBB|BBB\\-|BB\\+|BB|BB\\-|B\\+|B|B\\-|CCC\\+|CCC|CCC\\-|D)$",
-	         message = "Please enter a valid Fitch rating.")
+	         message = "{fitch.rating.format}")
 	private String fitchRating;
 	
-	@NotNull
+	@Min(value = 1)
+	@NotNull(message = "{rating.order.digits}")
 	private Integer order;
 
 	public String getMoodysRating() {

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/UpdateRatingDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/request/rating/UpdateRatingDto.java
@@ -1,0 +1,13 @@
+package com.pcs.tradingapp.dto.request.rating;
+
+public class UpdateRatingDto extends CreateRatingDto {
+	private int id;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/response/RatingInfoDto.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/dto/response/RatingInfoDto.java
@@ -1,0 +1,4 @@
+package com.pcs.tradingapp.dto.response;
+
+public record RatingInfoDto(Integer id, String moodysRating, String sandPRating, 
+		String fitchRating, Integer order) {}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/RatingNotFoundException.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/RatingNotFoundException.java
@@ -1,0 +1,13 @@
+package com.pcs.tradingapp.exceptions;
+
+public class RatingNotFoundException extends Exception {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	
+	public RatingNotFoundException(String message) {
+		super(message);
+	}
+	
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/RatingOrderNumberAlreadyExistsException.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/exceptions/RatingOrderNumberAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.pcs.tradingapp.exceptions;
+
+public class RatingOrderNumberAlreadyExistsException extends Exception {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	
+	public RatingOrderNumberAlreadyExistsException(String message) {
+		super(message);
+	}
+
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/repositories/RatingRepository.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/repositories/RatingRepository.java
@@ -1,9 +1,12 @@
 package com.pcs.tradingapp.repositories;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.pcs.tradingapp.domain.Rating;
 
 public interface RatingRepository extends JpaRepository<Rating, Integer> {
 
+	Optional<Rating> findByOrderNumber(Integer oderNumber);
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingMapper.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import com.pcs.tradingapp.domain.Rating;
+import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
 
 @Mapper(componentModel = "spring")
@@ -14,4 +15,8 @@ public interface RatingMapper {
 	public RatingInfoDto ratingToRatingInfoDto(Rating rating);
 
 	public List<RatingInfoDto> ratingsToRatingInfoDtos(List<Rating> ratings);
+
+	@Mapping(source = "order", target = "orderNumber")
+	@Mapping(target = "id", ignore = true)
+	public Rating createRatingDtoToRating(CreateRatingDto ratingDto);
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingMapper.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingMapper.java
@@ -7,6 +7,7 @@ import org.mapstruct.Mapping;
 
 import com.pcs.tradingapp.domain.Rating;
 import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
+import com.pcs.tradingapp.dto.request.rating.UpdateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
 
 @Mapper(componentModel = "spring")
@@ -19,4 +20,7 @@ public interface RatingMapper {
 	@Mapping(source = "order", target = "orderNumber")
 	@Mapping(target = "id", ignore = true)
 	public Rating createRatingDtoToRating(CreateRatingDto ratingDto);
+
+	@Mapping(source = "order", target = "orderNumber")
+	public Rating updateRatingDtoToRating(UpdateRatingDto ratingDto);
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingMapper.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingMapper.java
@@ -1,0 +1,17 @@
+package com.pcs.tradingapp.services.rating;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.pcs.tradingapp.domain.Rating;
+import com.pcs.tradingapp.dto.response.RatingInfoDto;
+
+@Mapper(componentModel = "spring")
+public interface RatingMapper {
+	@Mapping(source = "orderNumber", target = "order")
+	public RatingInfoDto ratingToRatingInfoDto(Rating rating);
+
+	public List<RatingInfoDto> ratingsToRatingInfoDtos(List<Rating> ratings);
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.pcs.tradingapp.constants.ApiMessages;
 import com.pcs.tradingapp.domain.Rating;
 import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
+import com.pcs.tradingapp.dto.request.rating.UpdateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
 import com.pcs.tradingapp.exceptions.RatingNotFoundException;
 import com.pcs.tradingapp.exceptions.RatingOrderNumberAlreadyExistsException;
@@ -42,5 +43,19 @@ public class RatingService {
 		
 		Rating rating = mapper.createRatingDtoToRating(ratingDto);
 		repository.save(rating);
+	}
+
+	public void updateRating(UpdateRatingDto ratingDto) {
+		Rating rating = mapper.updateRatingDtoToRating(ratingDto);
+		
+		repository.save(rating);
+	}
+
+	public void deleteRating(Integer id) throws RatingNotFoundException {
+		if (repository.findById(id).isEmpty()) {
+			throw new RatingNotFoundException(ApiMessages.RATING_NOT_FOUND);
+		}
+		
+		repository.deleteById(id);
 	}
 }

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingService.java
@@ -1,0 +1,35 @@
+package com.pcs.tradingapp.services.rating;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.pcs.tradingapp.constants.ApiMessages;
+import com.pcs.tradingapp.domain.Rating;
+import com.pcs.tradingapp.dto.response.RatingInfoDto;
+import com.pcs.tradingapp.exceptions.RatingNotFoundException;
+import com.pcs.tradingapp.repositories.RatingRepository;
+
+@Service
+public class RatingService {
+	private final RatingRepository repository;
+	private final RatingMapper mapper;
+	
+	public RatingService(RatingRepository repository, RatingMapper mapper) {
+		this.repository = repository;
+		this.mapper = mapper;
+	}
+	
+	public List<RatingInfoDto> getAllRatings() {
+		List<Rating> ratings = repository.findAll();
+
+		return mapper.ratingsToRatingInfoDtos(ratings);
+	}
+	
+	public RatingInfoDto getRatingById(int id) throws RatingNotFoundException {
+		Rating rating = repository.findById(id)
+				.orElseThrow(() -> new RatingNotFoundException(ApiMessages.RATING_NOT_FOUND));
+		
+		return mapper.ratingToRatingInfoDto(rating);
+	}
+}

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingService.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/services/rating/RatingService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 
 import com.pcs.tradingapp.constants.ApiMessages;
 import com.pcs.tradingapp.domain.Rating;
+import com.pcs.tradingapp.dto.request.rating.CreateRatingDto;
 import com.pcs.tradingapp.dto.response.RatingInfoDto;
 import com.pcs.tradingapp.exceptions.RatingNotFoundException;
+import com.pcs.tradingapp.exceptions.RatingOrderNumberAlreadyExistsException;
 import com.pcs.tradingapp.repositories.RatingRepository;
 
 @Service
@@ -31,5 +33,14 @@ public class RatingService {
 				.orElseThrow(() -> new RatingNotFoundException(ApiMessages.RATING_NOT_FOUND));
 		
 		return mapper.ratingToRatingInfoDto(rating);
+	}
+
+	public void createRating(CreateRatingDto ratingDto) throws RatingOrderNumberAlreadyExistsException {
+		if (repository.findByOrderNumber(ratingDto.getOrder()).isPresent()) {
+			throw new RatingOrderNumberAlreadyExistsException(ApiMessages.RATING_ORDER_NUMBER_EXISTS);
+		}
+		
+		Rating rating = mapper.createRatingDtoToRating(ratingDto);
+		repository.save(rating);
 	}
 }

--- a/trading-app-demo/src/main/resources/db/data.sql
+++ b/trading-app-demo/src/main/resources/db/data.sql
@@ -61,15 +61,30 @@ LIMIT 1;
 -- Data for table curve_point
 
 INSERT INTO curve_point(curve_id, as_of_date, term, curve_value, creation_date)
-SELECT * FROM (SELECT 1, '2025-06-30 10:00:00', 1.0, 0.5, NOW()) AS tmp
+SELECT * FROM (SELECT 25, '2025-06-30 10:00:00', 1.0, 0.5, NOW()) AS tmp
 WHERE NOT EXISTS (
 	SELECT 1 FROM  curve_point WHERE curve_id = 1 AND term = 1.0
 )
 LIMIT 1;
 
 INSERT INTO curve_point(curve_id, as_of_date, term, curve_value, creation_date)
-SELECT * FROM (SELECT 2, '2025-06-30 10:00:00', 1.0, 0.5, NOW()) AS tmp
+SELECT * FROM (SELECT 54, '2025-06-30 10:00:00', 1.0, 0.5, NOW()) AS tmp
 WHERE NOT EXISTS (
 	SELECT 1 FROM  curve_point WHERE curve_id = 2 AND term = 1.0
 )
+LIMIT 1;
+
+-- Data for table rating
+INSERT INTO rating (moodys_rating, sand_p_rating, fitch_rating, order_number)
+SELECT * FROM (
+    SELECT 'Baa1' AS moodys_rating, 'BBB+' AS sand_p_rating, 'BBB+' AS fitch_rating, 1 AS order_number
+) AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM rating WHERE order_number = 1)
+LIMIT 1;
+
+INSERT INTO rating (moodys_rating, sand_p_rating, fitch_rating, order_number)
+SELECT * FROM (
+    SELECT 'Ba2' AS moodys_rating, 'BB' AS sand_p_rating, 'BB' AS fitch_rating, 2 AS order_number
+) AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM rating WHERE order_number = 2)
 LIMIT 1;

--- a/trading-app-demo/src/main/resources/db/schema.sql
+++ b/trading-app-demo/src/main/resources/db/schema.sql
@@ -68,7 +68,8 @@ CREATE TABLE IF NOT EXISTS rating (
   moodys_rating VARCHAR(125),
   sand_p_rating VARCHAR(125),
   fitch_rating VARCHAR(125),
-  order_number INT
+  order_number INT NOT NULL,
+  UNIQUE INDEX unique_order_number (order_number)
 );
 
 CREATE TABLE IF NOT EXISTS rule_name (

--- a/trading-app-demo/src/main/resources/messages.properties
+++ b/trading-app-demo/src/main/resources/messages.properties
@@ -2,3 +2,8 @@ app.title=PCS - Trading App Demo
 typeMismatch.curvePoint.curveId=Curve id must be a positive integer
 curvePoint.term.digits=Term must be a decimal number with up to 2 digits and 1 decimal place
 curvePoint.value.digits=Value must be a decimal number with up to 2 digits and 1 decimal place
+
+typeMismatch.rating.order=Order number must be a positive integer
+moodys.rating.format=Please enter a valid Moody's rating
+sandp.rating.format=Please enter a valid S&P rating
+fitch.rating.format=Please enter a valid Fitch rating

--- a/trading-app-demo/src/main/resources/messages.properties
+++ b/trading-app-demo/src/main/resources/messages.properties
@@ -1,9 +1,12 @@
 app.title=PCS - Trading App Demo
 typeMismatch.curvePoint.curveId=Curve id must be a positive integer
+typeMismatch.curvePoint.term=Term must be a decimal number with up to 2 digits and 1 decimal place
+typeMismatch.curvePoint.value=Value must be a decimal number with up to 2 digits and 1 decimal place
 curvePoint.term.digits=Term must be a decimal number with up to 2 digits and 1 decimal place
 curvePoint.value.digits=Value must be a decimal number with up to 2 digits and 1 decimal place
 
 typeMismatch.rating.order=Order number must be a positive integer
+rating.order.digits=Order number must be a positive integer
 moodys.rating.format=Please enter a valid Moody's rating
 sandp.rating.format=Please enter a valid S&P rating
 fitch.rating.format=Please enter a valid Fitch rating

--- a/trading-app-demo/src/main/resources/messages_fr.properties
+++ b/trading-app-demo/src/main/resources/messages_fr.properties
@@ -1,10 +1,12 @@
-app.title=PCS - Trading App Demo
-
-typeMismatch.curvePoint.curveId=Le numéro d'identifiant doit être un entier positif.
-curvePoint.term.digits=Le terme doit être un nombre décimal avec jusqu'à 2 chiffres et 1 décimale.
-curvePoint.value.digits=La valeur doit être un nombre décimal avec jusqu'à 2 chiffres et 1 décimale.
-
-typeMismatch.rating.order=Le numéro d'ordre doit être un entier positif.
-moodys.rating.format=Veuillez saisir une notation Moody's valide.
-sandp.rating.format=Veuillez saisir une notation S&P valide.
-fitch.rating.format=Veuillez saisir une notation Fitch valide.
+#app.title=PCS - Trading App Demo
+#
+#typeMismatch.curvePoint.curveId=Le num\u00E9ro d''identifiant doit \u00EAtre un entier positif.
+#typeMismatch.curvePoint.term=Le terme doit \u00EAtre un nombre d\u00E9cimal avec jusqu''\u00E0 2 chiffres et 1 d\u00E9cimale.
+#typeMismatch.curvePoint.value=La valeur doit \u00EAtre un nombre d\u00E9cimal avec jusqu''\u00E0 2 chiffres et 1 d\u00E9cimale.
+#curvePoint.term.digits=Le terme doit \u00EAtre un nombre d\u00E9cimal avec jusqu''\u00E0 2 chiffres et 1 d\u00E9cimale.
+#curvePoint.value.digits=La valeur doit \u00EAtre un nombre d\u00E9cimal avec jusqu'\u00E0 2 chiffres et 1 d\u00E9cimale.
+#
+#typeMismatch.rating.order=Le num\u00E9ro d''ordre doit \u00EAtre un entier positif.
+#moodys.rating.format=Veuillez saisir une notation Moody's valide.
+#sandp.rating.format=Veuillez saisir une notation S&P valide.
+#fitch.rating.format=Veuillez saisir une notation Fitch valide.

--- a/trading-app-demo/src/main/resources/messages_fr.properties
+++ b/trading-app-demo/src/main/resources/messages_fr.properties
@@ -1,1 +1,10 @@
 app.title=PCS - Trading App Demo
+
+typeMismatch.curvePoint.curveId=Le numéro d'identifiant doit être un entier positif.
+curvePoint.term.digits=Le terme doit être un nombre décimal avec jusqu'à 2 chiffres et 1 décimale.
+curvePoint.value.digits=La valeur doit être un nombre décimal avec jusqu'à 2 chiffres et 1 décimale.
+
+typeMismatch.rating.order=Le numéro d'ordre doit être un entier positif.
+moodys.rating.format=Veuillez saisir une notation Moody's valide.
+sandp.rating.format=Veuillez saisir une notation S&P valide.
+fitch.rating.format=Veuillez saisir une notation Fitch valide.

--- a/trading-app-demo/src/main/resources/templates/rating/add.html
+++ b/trading-app-demo/src/main/resources/templates/rating/add.html
@@ -18,21 +18,21 @@
 			<div class="form-group">
 				<label for="moodysRating" class="col-sm-2 control-label">MoodysRating</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{moodysRating}" id="moodysRating" placeholder="MoodysRating" class="col-4">
+					<input type="text" th:field="*{moodysRating}" id="moodysRating" placeholder="MoodysRating" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('moodysRating')}" th:errors="*{moodysRating}"></p>
 				</div>
 			</div>
 			<div class="form-group">
 				<label for="sandPRating" class="col-sm-2 control-label">SandPRating</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{sandPRating}" id="sandPRating" placeholder="SandPRating" class="col-4">
+					<input type="text" th:field="*{sandPRating}" id="sandPRating" placeholder="SandPRating" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('sandPRating')}" th:errors="*{sandPRating}"></p>
 				</div>
 			</div>
 			<div class="form-group">
 				<label for="fitchRating" class="col-sm-2 control-label">FitchRating</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{fitchRating}" id="fitchRating" placeholder="FitchRating" class="col-4">
+					<input type="text" th:field="*{fitchRating}" id="fitchRating" placeholder="FitchRating" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('fitchRating')}" th:errors="*{fitchRating}"></p>
 				</div>
 			</div>

--- a/trading-app-demo/src/main/resources/templates/rating/list.html
+++ b/trading-app-demo/src/main/resources/templates/rating/list.html
@@ -17,7 +17,7 @@
 			<a href="/rulename/list">Rule</a>
 		</div>
 		<div class="col-6 text-right">
-			Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
+			Logged in user: <b th:inline="text"  class="user"> </b>
 			<form th:action="@{/app-logout}" method="POST">
 				<input type="submit" value="Logout"/>
 			</form>

--- a/trading-app-demo/src/main/resources/templates/rating/list.html
+++ b/trading-app-demo/src/main/resources/templates/rating/list.html
@@ -52,6 +52,7 @@
 			</tbody>
 		</table>
 	</div>
+	<p class="text-danger" th:if="${errorMsg != null}" th:text="${errorMsg}"></p>
 </div>
 </body>
 </html>

--- a/trading-app-demo/src/main/resources/templates/rating/update.html
+++ b/trading-app-demo/src/main/resources/templates/rating/update.html
@@ -18,28 +18,28 @@
 			<div class="form-group">
 				<label for="moodysRating" class="col-sm-2 control-label">MoodysRating</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{moodysRating}" id="moodysRating" placeholder="MoodysRating" class="col-4">
+					<input type="text" th:field="*{moodysRating}" id="moodysRating" placeholder="MoodysRating" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('moodysRating')}" th:errors="*{moodysRating}"></p>
 				</div>
 			</div>
 			<div class="form-group">
 				<label for="sandPRating" class="col-sm-2 control-label">SandPRating</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{sandPRating}" id="sandPRating" placeholder="SandPRating" class="col-4">
+					<input type="text" th:field="*{sandPRating}" id="sandPRating" placeholder="SandPRating" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('sandPRating')}" th:errors="*{sandPRating}"></p>
 				</div>
 			</div>
 			<div class="form-group">
 				<label for="fitchRating" class="col-sm-2 control-label">FitchRating</label>
 				<div class="col-sm-10">
-					<input type="number" th:field="*{fitchRating}" id="fitchRating" placeholder="FitchRating" class="col-4">
+					<input type="text" th:field="*{fitchRating}" id="fitchRating" placeholder="FitchRating" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('fitchRating')}" th:errors="*{fitchRating}"></p>
 				</div>
 			</div>
 			<div class="form-group">
 				<label for="order" class="col-sm-2 control-label">Order</label>
 				<div class="col-sm-10">
-					<input type="text" th:field="*{order}" id="order" placeholder="FitchRating" class="col-4">
+					<input type="text" th:field="*{order}" id="order" placeholder="Order" class="col-4">
 					<p class="text-danger" th:if="${#fields.hasErrors('order')}" th:errors="*{order}"></p>
 				</div>
 			</div>

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/RatingControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/RatingControllerIT.java
@@ -1,7 +1,10 @@
 package com.pcs.tradingapp.it;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -10,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -37,5 +41,94 @@ public class RatingControllerIT {
     		.andExpect(view().name("rating/add"))
     		.andExpect(model().attributeExists("rating"))
     		.andExpect(status().is2xxSuccessful());
+    }
+	
+	@Test
+    public void testAddRating_withValidData_shouldRedirectToList() throws Exception {
+        mockMvc.perform(post("/rating/add")
+                        .param("moodysRating", "Aaa")
+                        .param("sandPRating", "AAA")
+                        .param("fitchRating", "BBB")
+        				.param("order", "8"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/rating/list"));
+    }
+	
+	@Test
+    public void testAddRating_withExistingOrderNumber_shouldReturnAddView() throws Exception {
+        mockMvc.perform(post("/rating/add")
+                        .param("moodysRating", "Aaa")
+                        .param("sandPRating", "AAA")
+                        .param("fitchRating", "BBB")
+        				.param("order", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rating/add"));
+    }
+
+    @Test
+    public void testAddRating_withInvalidData_shouldReturnAddView() throws Exception {
+        mockMvc.perform(post("/rating/add")
+        		.param("moodysRating", "123")
+                .param("sandPRating", "AAAAA")
+                .param("fitchRating", "BABA")
+				.param("order", "1")
+			)
+            .andExpect(status().isOk())
+            .andExpect(view().name("rating/add"));
+    }
+
+    @Test
+    public void testShowUpdateForm_withExistingId_shouldReturnUpdateView() throws Exception {
+        mockMvc.perform(get("/rating/update/1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rating/update"))
+                .andExpect(model().attributeExists("rating"));
+    }
+
+    @Test
+    public void testShowUpdateForm_withUnknownId_shouldRedirectToListWithError() throws Exception {
+        mockMvc.perform(get("/rating/update/999"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/rating/list"))
+                .andExpect(flash().attributeExists("errorMsg"));
+    }
+
+    @Test
+    public void testUpdateRating_withValidData_shouldRedirectToList() throws Exception {
+        mockMvc.perform(post("/rating/update/1")
+		                .param("moodysRating", "Aaa")
+		                .param("sandPRating", "AAA")
+		                .param("fitchRating", "BBB")
+						.param("order", "8"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/rating/list"));
+    }
+
+    @Test
+    public void testUpdateRating_withBlankOrder_shouldReturnUpdateView() throws Exception {
+        mockMvc.perform(post("/rating/update/1")
+	        		.param("moodysRating", "Aaa")
+	                .param("sandPRating", "AAA")
+	                .param("fitchRating", "BBB")
+					.param("order", "")
+	                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        		)
+            .andExpect(status().isOk())
+            .andExpect(view().name("rating/update"));
+    }
+
+    @Test
+    public void testDeleteRating_shouldRedirectToList() throws Exception {
+        mockMvc.perform(get("/rating/delete/1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/rating/list"));
+    }
+    
+    @Test
+    public void testDeleteRating_shouldThrowException() throws Exception {
+        mockMvc.perform(get("/rating/delete/777"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/rating/list"))
+                .andExpect(flash().attributeExists("errorMsg"));
     }
 }

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/RatingControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/RatingControllerIT.java
@@ -30,4 +30,12 @@ public class RatingControllerIT {
 			.andExpect(model().attributeExists("ratings"))
 			.andExpect(status().is2xxSuccessful());
 	}
+	
+	@Test
+    public void testShowAddForm_shouldReturnAddFormView() throws Exception {
+    	mockMvc.perform(get("/rating/add"))
+    		.andExpect(view().name("rating/add"))
+    		.andExpect(model().attributeExists("rating"))
+    		.andExpect(status().is2xxSuccessful());
+    }
 }

--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/RatingControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/RatingControllerIT.java
@@ -1,0 +1,33 @@
+package com.pcs.tradingapp.it;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.pcs.tradingapp.config.DevSecurityConfiguration;
+
+@Import(DevSecurityConfiguration.class)
+@AutoConfigureMockMvc
+@SpringBootTest(properties = "spring.profiles.active=test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class RatingControllerIT {
+	@Autowired
+	private MockMvc mockMvc;
+	
+	@Test
+	public void testIndex_shouldReturnListView() throws Exception {
+		mockMvc.perform(get("/rating/list"))
+			.andExpect(view().name("rating/list"))
+			.andExpect(model().attributeExists("ratings"))
+			.andExpect(status().is2xxSuccessful());
+	}
+}

--- a/trading-app-demo/src/test/resources/db/data.sql
+++ b/trading-app-demo/src/test/resources/db/data.sql
@@ -22,7 +22,14 @@ VALUES ('ACC002', 'FX', 250000.00, 260000.00, 1.1025, 1.1035, 'EUR/USD', '2024-0
 
 --Data dor table curve_point
 INSERT INTO curve_point(curve_id, as_of_date, term, curve_value, creation_date)
-VALUES (1, '2025-06-30 10:00:00', 1.0, 0.5, NOW());
+VALUES (25, '2025-06-30 10:00:00', 1.0, 0.5, NOW());
 
 INSERT INTO curve_point(curve_id, as_of_date, term, curve_value, creation_date)
-VALUES (2, '2025-06-30 10:00:00', 1.0, 0.5, NOW());
+VALUES (54, '2025-06-30 10:00:00', 1.0, 0.5, NOW());
+
+-- Data for table rating
+INSERT INTO rating (moodys_rating, sand_p_rating, fitch_rating, order_number)
+VALUES('Baa1', 'BBB+', 'BBB+', 1);
+
+INSERT INTO rating (moodys_rating, sand_p_rating, fitch_rating, order_number)
+VALUES ('Ba2', 'BB', 'BB', 2);

--- a/trading-app-demo/src/test/resources/db/schema.sql
+++ b/trading-app-demo/src/test/resources/db/schema.sql
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS rating (
   moodys_rating VARCHAR(125),
   sand_p_rating VARCHAR(125),
   fitch_rating VARCHAR(125),
-  order_number INT
+  order_number INT NOT NULL UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS rule_name (


### PR DESCRIPTION
# CRUD complet de l'entité Rating

## Description
Cette PR implémente un CRUD complet pour l'entité Rating, comprenant la gestion en backend et les vues associées.

---

## Principales modifications
### Templates
Ajout d’un message d’erreur conditionnel dans la vue list pour afficher une erreur lors d'une redirection après exception RatingNotFoundException.

Correction des types des inputs de rating pour correspondre aux formats des différentes agences de notation. 

### DTOs
Création des classes : 
 - `CreateRatingDto`, avec règles de validation ;
 - `UpdateRatingDto`, qui étend CreateRatingDto en ajoutant un champ id.

Création du record `RatingInfoDto` pour les réponses avec les propriétés utiles à l’affichage.

### Mapper
Création de `RatingMapper` avec MapStruct (annotation `@Mapper`).
Ajout des méthodes de mapping entre entité et DTOs.

La propriété `id`, lorsqu'elle ne nécessite pas d'être mappée, est ignorée pour éviter les warnings.

### RatingService
Ajout de RatingService avec méthodes de création, mise à jour, lecture et suppression.
Utilisation du mapper pour conversion entité <-> DTO.
Gestion de l’exception RatingNotFoundException pour les opérations effectuées sur un objet existant.

### Gestion des erreurs
#### Exceptions
Ajout de RatingNotFoundException pour signaler les erreurs liées à une Rating non trouvée.

#### Constantes
Ajout d’une constante `RATING_NOT_FOUND` dans ApiMessages pour uniformiser les messages d’erreur.

### Configuration
#### `messages.properties`
Ajout de constantes permettant de retourner un message d'erreur personnalisé en cas de TypeMismatchException survenue lors de la saisie de données incompatibles avec l'entité dans les champs de type texte. 
Ajout de constantes pour centraliser les messages d'erreur de validation des DTO. 

#### `messages-fr.properties`
Traduction des messages. L'ensemble du fichier a été commenté en attendant la configuration de l'anglais comme langue par défaut. 

### Base de données
#### `schema.sql`
Ajout d'une contrainte d'unicité sur le champ order_number. 

#### `data.sql`
Ajout d’insertion de données de démonstration dans les scripts MySQL (dev) et H2 (test) avec contrôle d’unicité sur le champ `order_number` dans la base de données de dev.

---

# Tests
Les tests couvrent les principaux cas d’usage et assurent la qualité des mappings et de la logique métier.

## Tests d'intégration
### `RatingControllerIT`
Tests complets sur :
 - affichage de la liste de Rating,
 - chargement de la vue du formulaire d'ajout,
 - création d'une Rating avec tous les paramètres requis,
 - création d'une Rating avec des paramètres invalides,
 - création d'une Rating avec un champ requis vide,
 - chargement de la vue du formulaire de mise à jour avec un id existant,
 - chargement de la vue du formulaire de mise à jour avec un id inconnu,
 - mise à jour d'une Rating avec tous les paramètres requis,
 - mise à jour d'une Rating avec paramètres invalides,
 - suppression d’une Rating existante,
 - gestion de la suppression d’une Rating inconnue.

## Tests unitaires
### Service
Test unitaire vérifiant que l’exception RatingNotFoundException est bien lancée lorsque l’on tente de récupérer une Rating qui n'existe pas.

### Mapper
Test unitaire s’assurant que le mapping de Rating vers RatingInfoDto fonctionne correctement en mappant bien le champ orderNumber côté Rating au champ order côté RatingInfoDto.

Test nitaire s'assurant que le mapping de UpdateRatingDto vers l'entité Rating fonctionne correctement en mappant bien le champ order côté RatingInfoDto au champ orderNumber côté Rating. 

![jacoco-RatingController](https://github.com/user-attachments/assets/bdc0bc15-b1f1-47f4-a603-b285ba81711b)
![jacoco-ratingService](https://github.com/user-attachments/assets/f9503362-76f6-4e64-857f-21efecb72f55)
