### PR TITLE
Chore/log4j2

### DIFF
--- a/trading-app-demo/.gitignore
+++ b/trading-app-demo/.gitignore
@@ -13,3 +13,6 @@
 
 ## IntelliJ
 *.iml
+
+# logs
+/logs

--- a/trading-app-demo/pom.xml
+++ b/trading-app-demo/pom.xml
@@ -32,14 +32,37 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-web</artifactId>
+				<exclusions>
+					<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!--  logging: log4j2  -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/trading-app-demo/src/main/java/com/pcs/tradingapp/config/filters/RequestResponseLoggingFilter.java
+++ b/trading-app-demo/src/main/java/com/pcs/tradingapp/config/filters/RequestResponseLoggingFilter.java
@@ -1,0 +1,47 @@
+package com.pcs.tradingapp.config.filters;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class RequestResponseLoggingFilter extends HttpFilter {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	
+	private static final Logger logger = LogManager.getLogger(RequestResponseLoggingFilter.class);
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+        
+        if (req.getRequestURI().endsWith(".css")) {
+        	chain.doFilter(request, response);
+        	return;
+        }
+
+        logger.info("[HTTP REQUEST] {} {}, from {}", req.getMethod(), req.getRequestURI(), req.getRemoteAddr());
+        
+        chain.doFilter(request, response);
+
+        logger.info(
+                "[HTTP RESPONSE] {}", res.getStatus());
+    }
+
+}

--- a/trading-app-demo/src/main/resources/application.properties
+++ b/trading-app-demo/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-
-logging.level.org.springframework=INFO
-
 ################### DataSource Configuration ##########################
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=${DB_URL}

--- a/trading-app-demo/src/main/resources/log4j2.xml
+++ b/trading-app-demo/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href=""?>
+<Configuration>
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] [%-5level] %logger{36} - %msg%n"/>
+        </Console>        
+   		<File name="REQUESTS_LOG" fileName="logs/requests.log">
+	        <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%-5level] %logger{36} - %msg%n"/>
+   		</File>
+    </Appenders>
+    
+    <Loggers>
+    	<Root level="DEBUG">
+    		<AppenderRef ref="Console"/>
+    	</Root>
+    	<Logger name="com.pcs.tradingapp.config.filters" additivity="false" level="DEBUG">
+    		<AppenderRef ref="REQUESTS_LOG"/>
+    	</Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
# Ajout d'un logger et d'un filtre de requêtes

## Description
Cette PR définit la configuration d'un logger via Log4j2 et la journalisation des requêtes entrantes et réponses sortantes. 

## Principales modifications

### pom.xml
Exclusion du logger par défaut de toutes les dépendances qui l'embarques (Spring Boot Starter Data JPA, Spring Boot Starter Web et Spring Boot Starter Test). 

Ajout de la dépendance `spring-boot-starter-log4j2` pour définir log4j2 comme framework de logging. 

### application.properties
Suppression de la ligne de configuration du logger par défaut (`logging.level.org.springframework`). 

### log4j2.xml
Ajout d'une configuration pour le logger : 
 - formatage personnalisé des logs 
 - configuration de 2 appenders : 
  - console : pour afficher tous les logs dans la sortie standard;
  - file :  /logs/requests.log stocker les logs du filtre de requête/réponses. 

 ### RequestResponseLoggingFilter
Créaiton d'un filtre qui intercepte le trafic HTTP entrant ou sortant et journalise les requêtes (méthode HTTP, URI de la requête, adresse distante) et les réponses (statut HTTP). 
Ajout d'une condition pour éviter de logger toutes les requêtes vers des ressources `*.css` afin de ne pas polluer les logs avec les informations de chargement des feuilles de style de chaque page. 

---

Ces changements centralisent la gestion du logging tout en facilitant l'évolutivité du système de journalisation, la traçabilité des événements et le debug. 

<img width="1009" height="199" alt="logs" src="https://github.com/user-attachments/assets/3c23b205-1718-497b-b538-8bb36b7bb9c9" />
