### PR TITLE
test(auth): add IT for admin authorization on /admin/home endpoint

### DIFF
--- a/trading-app-demo/src/test/java/com/pcs/tradingapp/it/HomeControllerIT.java
+++ b/trading-app-demo/src/test/java/com/pcs/tradingapp/it/HomeControllerIT.java
@@ -1,0 +1,47 @@
+package com.pcs.tradingapp.it;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@SpringBootTest(properties = "spring.profiles.active=test")
+@AutoConfigureMockMvc
+public class HomeControllerIT {
+	
+	@Autowired
+	MockMvc mockMvc;
+	
+	@Test 
+    @WithMockUser(roles = "ADMIN")
+    public void testAdminAccess_withAdminRole_shouldRedirectToView() throws Exception {
+    	mockMvc.perform(get("/admin/home"))
+    	.andExpect(status().is3xxRedirection())
+    	.andExpect(redirectedUrl("/bidlist/list"));
+    }	
+	
+	@Test 
+    @WithMockUser
+    public void testAdminAccess_withUserRole_shouldReturnClientError() throws Exception {
+    	mockMvc.perform(get("/admin/home"))
+    	.andExpect(status().is4xxClientError());
+    }
+
+	@Test 
+	@WithMockUser
+	public void testHome_shouldReturnHomeView() throws Exception {
+		mockMvc.perform(get("/"))
+		.andExpect(status().is2xxSuccessful())
+		.andExpect(view().name("home"));
+	}
+}


### PR DESCRIPTION
# Tests

## HomeControllerIT

Création de la classe HomeControllerIT avec les annotations :
 - `@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)` pour réinitialiser le context après chaque test,
 - `@SpringBootTest(properties="spring.profiles.active=test")` pour activer le profil de test,
 - `@AutoconfigureMockMvc` pour permettre la simulation des requêtes HTTP

Ajout de 3 méthodes Add HomeControllerIT with 3 methods:
 - `testAdminAccess_withAdminRole_shouldRedirectToView()` vérifie que seuls les utilisateurs ayant le rôle ADMIN sont redirigés (statut 3xx) lors de l'appel au endpoint "/admin/**".
 - `testAdminAccess_withUserRole_shouldReturnClientError()`  s’assure que les utilisateurs sans le rôle ADMIN reçoivent une erreur client (statut 4xx) lors de l'appel au endpoint "/admin/**".
 - `testHome_shouldReturnHomeView()`  teste le statut et la vue retournés lors de l’accès au endpoint “/”.

---

<img width="903" height="216" alt="jacoco-HomeController" src="https://github.com/user-attachments/assets/29eccf06-728d-46f4-bd18-4ed749d338ae" />
