### PR TITLE
fix(data): correct condition in curve_point seed SQL

### DIFF
--- a/trading-app-demo/src/main/resources/db/data.sql
+++ b/trading-app-demo/src/main/resources/db/data.sql
@@ -63,14 +63,14 @@ LIMIT 1;
 INSERT INTO curve_point(curve_id, as_of_date, term, curve_value, creation_date)
 SELECT * FROM (SELECT 25, '2025-06-30 10:00:00', 1.0, 0.5, NOW()) AS tmp
 WHERE NOT EXISTS (
-	SELECT 1 FROM  curve_point WHERE curve_id = 1 AND term = 1.0
+	SELECT 1 FROM  curve_point WHERE curve_id = 25 AND term = 1.0
 )
 LIMIT 1;
 
 INSERT INTO curve_point(curve_id, as_of_date, term, curve_value, creation_date)
 SELECT * FROM (SELECT 54, '2025-06-30 10:00:00', 1.0, 0.5, NOW()) AS tmp
 WHERE NOT EXISTS (
-	SELECT 1 FROM  curve_point WHERE curve_id = 2 AND term = 1.0
+	SELECT 1 FROM  curve_point WHERE curve_id = 54 AND term = 1.0
 )
 LIMIT 1;
 


### PR DESCRIPTION
# Correctif du schema SQL

## Description
Cette pull request corrige la génération des données d’initialisation dans le script schema.sql pour la table curve_point.


### Modifications
Ajustement des conditions WHERE NOT EXISTS pour cibler les bons curve_id (25 et 54) au lieu des identifiants 1 et 2.

---

Évite l’insertion répétée de lignes de test en double lors de réinitialisations de la base ou de l’exécution répétée du script.